### PR TITLE
Group by category changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>vue-gantt-example</title>
+    <link rel="stylesheet" type="text/css" href="http://unpkg.com/croud-style-guide@latest/semantic/dist/semantic.min.css">
   </head>
   <body>
     <div id="app"></div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,8 @@
         complete: '#8bccba',
         active: '#6bc2e2',
         in_progress: '#fbbd08',
-    }" :readOnly="false">
+    }" :readOnly="false"
+    :category-groupings="true">
         <template slot="context-menu" scope="scope">
             <li @click="selected(scope.selected)" class="item">
                 <i class="edit icon"></i>View

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,7 +49,7 @@ export default {
                     x: 0,
                     width: 0,
                     readOnly: true,
-                    group_by: 'foo',
+                    group_by: '',
                 },
                 {
                     title: 'A New Event',
@@ -71,7 +71,7 @@ export default {
                     frequency: {
                         key: 'weekly',
                     },
-                    dependencies: [0, 1],
+                    dependencies: [], // [0, 1],
                     status: 'active',
                     x: 0,
                     width: 0,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,11 @@
 <template>
   <div id="app">
-    <gantt :calculate="false" :events="ganttData" :end-period="endPeriod" :start-period="startPeriod" @load-more="loadMore" @selected="selected" :grouping="true" :show-repeats="false" :status-colors="{
+    <gantt :calculate="false" :events="ganttData" :end-period="endPeriod" :start-period="startPeriod" @load-more="loadMore" @selected="selected" :grouping="true" :show-repeats="repeats" :status-colors="{
         complete: '#8bccba',
         active: '#6bc2e2',
         in_progress: '#fbbd08',
     }" :readOnly="false"
-    :category-groupings="true">
+    :category-groupings="group">
         <template slot="context-menu" scope="scope">
             <li @click="selected(scope.selected)" class="item">
                 <i class="edit icon"></i>View
@@ -15,6 +15,14 @@
             </li>
         </template>
     </gantt>
+    <div>
+        <input type="checkbox" v-model="group"/>
+        <label>Group Items</label>
+    </div>
+    <div>
+        <input type="checkbox" v-model="repeats"/>
+        <label>Show Repeats</label>
+    </div>
   </div>
 </template>
 
@@ -36,6 +44,8 @@ export default {
             selectedBlock: null,
             startPeriod: moment().startOf('month').startOf('week'),
             endPeriod: moment().add(1, 'months'),
+            group: true,
+            repeats: true,
             params: {
                 from: moment().subtract(1, 'years').format('YYYY-MM-DD'),
                 to: moment().subtract(1, 'years').add(1, 'months').format('YYYY-MM-DD'),
@@ -135,7 +145,6 @@ export default {
                 return event
             })
             this.initialLoad = true
-            // console.log(this.ganttData)
         })
     },
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -166,11 +166,10 @@ export default {
 
 <style>
 #app {
-  font-family: 'Avenir', Helvetica, Arial, sans-serif;
+  font-family: 'Lato', Verdana, Geneva, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
+  color: #292929;
   margin-top: 60px;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,6 +49,7 @@ export default {
                     x: 0,
                     width: 0,
                     readOnly: true,
+                    group_by: 'foo',
                 },
                 {
                     title: 'A New Event',
@@ -61,6 +62,7 @@ export default {
                     status: 'in_progress',
                     x: 0,
                     width: 0,
+                    group_by: 'foo',
                 },
                 {
                     title: 'Dependent Event',
@@ -73,6 +75,7 @@ export default {
                     status: 'active',
                     x: 0,
                     width: 0,
+                    group_by: 'bar',
                 },
                 {
                     title: 'Another Event',
@@ -85,6 +88,7 @@ export default {
                     status: 'active',
                     x: 0,
                     width: 0,
+                    group_by: 'bar',
                 },
             ],
         }

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -3,11 +3,13 @@
         <div id="adpcalendar">
             <div id="timeline-sidebar">
                 <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + blockHeight : blockHeight}px`}">
-                    <div id="category-header" slot="category-header" :data="i" @click="i.show =! i.show">
-                        <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
-                        <div v-if="i.show" class="caret">&rsaquo;</div>
-                        <div v-else class="caret collapsed">&rsaquo;</div>
-                    </div>
+                    <slot name="category-header" :data="i">
+                        <div id="category-header" @click="i.show =! i.show">
+                            <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
+                            <div v-if="i.show" class="caret">&rsaquo;</div>
+                            <div v-else class="caret collapsed">&rsaquo;</div>
+                        </div>
+                    </slot>
                     <svg id="event-types" ref="svg" :width="titleWidth" :height='i.height' v-if="i.show">
                         <g class="rows">
                             <rect v-for="(block, $index) in i.groupings" x="0" :y="blockHeight * $index" width="100%" :height="blockHeight" stroke="#f5f5f5" stroke-width="2" :key="$index"></rect>

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -6,7 +6,7 @@
                     <div id="category-header" @click="i.show =! i.show">
                         <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
                         <div v-if="i.show" class="carret">&rsaquo;</div>
-                        <div v-else class="carret-collapsed">&rsaquo;</div>
+                        <div v-else class="carret collapsed">&rsaquo;</div>
                     </div>
                     <svg id="event-types" ref="svg" :width="titleWidth" :height='i.height' v-if="i.show">
                         <g class="rows">
@@ -688,15 +688,14 @@
 
         .carret {
             font-size: 2rem;
+            color: #666666;
             width: 10%;
-            transform: scale(1, 1.4) rotate(90deg);
+            transform: scale(1, 1.8) rotate(90deg);
+            text-align: center;
+
+            &.collapsed {
+                transform: translateX(-2.5px) translateY(-4px) scale(1.8, 1);
         }
-
-        .carret-collapsed {
-            font-size: 2rem;
-            width: 10%;
-            transform: translateX(-1.5px) scale(1.4, 1);
-
         }
     }
 

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -28,7 +28,7 @@
                                 <g>
                                     <g class="titles">
                                 <g v-for="(line, $index) in gridLines" v-if="$index % smartGrids === 1" :key="$index">
-                                    <text text-anchor="middle" :x="($index - 1) * hourWidth + titleWidth" y="20">{{ line }}</text>
+                                            <text text-anchor="middle" :x="($index - 1) * hourWidth + titleWidth" y="10">{{ line }}</text>
                                 </g>
 
                                 <foreignObject :x='svgWidth - 500' width="1" height="100%" v-if="inifinteScroll">
@@ -46,7 +46,7 @@
                                     <rect @click="i.show = false" x="0" :y="0" width="100%" fill="transparent" :height="blockHeight"></rect>
                                 </g>
                                 <g class="rows">
-                                    <rect v-for="(block, $index) in i.groupings" x="0" :y="blockHeight * $index + 35" width="100%" :height="blockHeight" stroke="#f5f5f5" stroke-width="2" :key="$index"></rect>
+                                    <rect v-for="(block, $index) in i.groupings" x="0" :y="blockHeight * $index + blockHeight" width="100%" :height="blockHeight" stroke="#f5f5f5" stroke-width="2" :key="$index"></rect>
                                 </g>
 
                                 <g class="graph">
@@ -86,7 +86,6 @@
                                     </g>
                                 </g>
                             </g>
-                            <rect v-else x="0" y="10" width="100%" height="35" fill="transparent"></rect>
                         </svg>
                         <!-- <div v-else :style="{height: `${topMargin}px`}" @click="i.show =! i.show"></div> -->
                     </div>

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -3,9 +3,9 @@
         <div id="adpcalendar">
             <div id="timeline-sidebar">
                 <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + blockHeight : blockHeight}px`}">
-                    <div class="category-header-wrapper">
+                    <div class="category-header-wrapper" :style="{'height': `${blockHeight}px`}">
                         <slot name="category-header" :data="i">
-                            <div class="category-header" :style="{'height': `${blockHeight}px`}" @click="i.show =! i.show">
+                            <div class="category-header" @click="i.show = !i.show">
                                 <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
                                 <div v-if="i.show" class="caret collapsed">&rsaquo;</div>
                                 <div v-else class="caret">&rsaquo;</div>

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -358,6 +358,10 @@
                     backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='${this.scaleWidth * 7}' height='100' viewBox='0 0 ${this.scaleWidth * 7} 100'%3E%3Cg fill-rule='evenodd'%3E%3Cg fill='%239C92AC' fill-opacity='0.4'%3E%3Cpath opacity='.5' d='M0 0 H 5 V 100 H 0 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
                 }
             },
+
+            currentEvent() {
+                return this.events[this.events.indexOf(this.localSelected)]
+            },
         },
 
         filters: {
@@ -567,6 +571,17 @@
 
         watch: {
             groupings: 'buildGroupByData',
+
+            'currentEvent.offset': {
+                handler() {
+                    const position = this.calculate ? this.calculatedPosition : this.position
+                    position(this.currentEvent)
+                    if (!this.currentEvent.children) return
+                    this.currentEvent.children.forEach((child) => {
+                        position(child)
+                    })
+                },
+            },
         },
     }
 </script>

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -683,12 +683,20 @@
         .title {
             padding: 0 0 0 10px;
             width: 90%;
+            text-align: left;
         }
 
         .carret {
-            font-size: 0.9rem;
+            font-size: 2rem;
             width: 10%;
-            transform: scale(1.4,-0.8);
+            transform: scale(1, 1.4) rotate(90deg);
+        }
+
+        .carret-collapsed {
+            font-size: 2rem;
+            width: 10%;
+            transform: translateX(-1.5px) scale(1.4, 1);
+
         }
     }
 

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -462,8 +462,12 @@
 
                     const filteredGroups = {}
                     Object.keys(grouped).forEach((prop) => {
-                        if (grouped[prop].length) { filteredGroups[prop] = grouped[prop] }
+                        if (prop !== 'misc' && grouped[prop].length) { filteredGroups[prop] = grouped[prop] }
                     })
+
+                    if (!grouped.misc) return filteredGroups
+
+                    filteredGroups.misc = grouped.misc
                     return filteredGroups
                 }, startObj)
 

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -689,7 +689,6 @@
     }
     #adpcalendar {
         overflow: hidden;
-        margin-top: -20px;
         margin-bottom: 20px;
         display: flex;
     }

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -44,7 +44,7 @@
                     </svg>
                 </div>
                     <div v-for="(i, rootIndex) in groupByData" :key="rootIndex" :style="{height: `${i.show ? i.height + getTopMargin : getTopMargin}px`}">
-                        <svg ref="svg" id="timeline-events" :width="svgWidth" :height="i.show ? i.height + getTopMargin : 0"  v-if="i.show">
+                        <svg ref="svg" id="timeline-events" :width="svgWidth" :height="i.show ? i.height + getTopMargin : 0"  v-show="i.show">
                             <g>
                                 <g>
                                     <rect @click="i.show = false" x="0" :y="0" width="100%" fill="transparent" :height="blockHeight" stroke="#eceaef" stroke-width="2"></rect>
@@ -92,7 +92,7 @@
                                 </g>
                             </g>
                         </svg>
-                        <div v-else class="closed-bar" :style="{width: `${svgWidth}px`, height: `${blockHeight}px`}" @click="i.show = !i.show"></div>
+                        <div v-show="!i.show" class="closed-bar" :style="{width: `${svgWidth}px`, height: `${blockHeight}px`}" @click="i.show = !i.show"></div>
                     </div>
                 </div>
             </div>

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -4,10 +4,10 @@
             <div id="timeline-sidebar">
                 <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + blockHeight : blockHeight}px`}">
                     <slot name="category-header" :data="i">
-                        <div id="category-header" @click="i.show =! i.show">
+                        <div class="category-header" :style="{'height': `${blockHeight}px`}" @click="i.show =! i.show">
                             <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
-                            <div v-if="i.show" class="caret">&rsaquo;</div>
-                            <div v-else class="caret collapsed">&rsaquo;</div>
+                            <div v-if="i.show" class="caret collapsed">&rsaquo;</div>
+                            <div v-else class="caret">&rsaquo;</div>
                         </div>
                     </slot>
                     <svg id="event-types" ref="svg" :width="titleWidth" :height='i.height' v-if="i.show">
@@ -89,7 +89,7 @@
                                 </g>
                             </g>
                         </svg>
-                        <div v-else id="closed-bar" :style="{width: `${svgWidth}px`, height: `${topMargin}px`}" @click="i.show = !i.show"></div>
+                        <div v-else class="closed-bar" :style="{width: `${svgWidth}px`, height: `${blockHeight}px`}" @click="i.show = !i.show"></div>
                     </div>
                 </div>
             </div>
@@ -384,7 +384,7 @@
 
             gridPatternStyles() {
                 return {
-                    marginTop: '35px',
+                    marginTop: `${this.topMargin}px`,
                     marginLeft: `${this.titleWidth}px`,
                     height: `${this.limits.height}px`,
                     backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='${this.scaleWidth * 7}' height='100' viewBox='0 0 ${this.scaleWidth * 7} 100'%3E%3Cg fill-rule='evenodd'%3E%3Cg fill='%239C92AC' fill-opacity='0.4'%3E%3Cpath opacity='.5' d='M0 0 H 5 V 100 H 0 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
@@ -666,8 +666,7 @@
         display: flex;
     }
 
-    #category-header {
-        height: 35px;
+    .category-header {
         display: flex;
         align-items: center;
         justify-content: center;
@@ -686,16 +685,19 @@
             font-size: 2rem;
             color: #666666;
             width: 10%;
-            transform: scale(1, 1.8) rotate(90deg);
-            text-align: center;
+            display: flex;
+            justify-content: center;
+            padding: 0 2px 3px 0;
+            transform: scale(1, 1.3);
 
             &.collapsed {
-                transform: translateX(-2.5px) translateY(-4px) scale(1.8, 1);
+                padding: 0;
+                transform: scale(1.3, 1) rotate(90deg);
             }
         }
     }
 
-    #closed-bar{
+    .closed-bar {
         background-color: #f5f5f5;
         border: solid 1px #eceaef;
     }

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -192,7 +192,7 @@
                 topMargin: 35,
                 localSelected: null,
                 cloned: null,
-                groupByData: {},
+                groupByData: [],
             }
         },
 

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -46,7 +46,7 @@
                                     </g>
 
                                     <g class="blocks">
-                                        <g class="block" v-for="(block, $index) in nodes" :key="$index">
+                                        <g class="block" v-for="(block, $index) in i.events" :key="$index">
                                             <title>{{ block.title }}</title>
 
                                             <rect @contextmenu.prevent="openContext($event, block)" @click="select(block, $index)" @mousedown="adjustStart(block, $event)" rx="2" ry="2" :x="block.x" :y='block.y' :width='block.width' :height='block.height' :class="{editable: !readOnly && !block.readOnly}" :style="{fill: block.label}">

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -255,43 +255,6 @@
                 return []
             },
 
-            nodes() {
-                const position = this.calculate ? this.calculatedPosition : this.position
-                this.groupings = []
-                this.links = []
-
-                return this.repeats.map((event, i) => {
-                    let index = this.groupings.indexOf(event.title.toLowerCase())
-                    if (index === -1) {
-                        index = this.groupings.length
-                        this.groupings.push(event.title.toLowerCase())
-                    }
-                    event.event_index = this.grouping ? index : i
-
-                    if (this.showRepeats && event.children && event.children.length) {
-                        event.children.map((ch) => {
-                            ch.event_index = index
-                            position(ch)
-                            return ch
-                        })
-                    }
-
-                    if (event.dependencies) {
-                        event.dependencies.map((dep) => {
-                            this.links.push([
-                                this.events[dep],
-                                event,
-                            ])
-
-                            return dep
-                        })
-                    }
-
-                    position(event)
-                    return event
-                })
-            },
-
             limits() {
                 const limits = {
                     start: this.startPeriod,

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -405,7 +405,7 @@
                 const titleGroupings = { misc: [] }
 
                 const startObj = this.categoryGroupings !== true ? this.categoryGroupings : { misc: [] }
-                const test = this.nodes.reduce((grouped, item, i, array, sortKey = item.group_by) => {
+                const processNodes = this.nodes.reduce((grouped, item, i, array, sortKey = item.group_by) => {
                     if (this.categoryGroupings === true && sortKey) {
                         grouped[sortKey] = grouped[sortKey] || []
                     }
@@ -427,9 +427,9 @@
                     return grouped
                 }, startObj)
 
-                this.groupByData = Object.keys(test).map(group => ({
+                this.groupByData = Object.keys(processNodes).map(group => ({
                     title: group,
-                    blocks: test[group],
+                    blocks: processNodes[group],
                     groupings: titleGroupings[group],
                     show: true,
                     height: titleGroupings[group].length * (this.blockHeight),

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -4,7 +4,7 @@
             <div id="timeline-sidebar">
                 <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + blockHeight : blockHeight}px`}">
                     <div id="category-header" @click="i.show =! i.show">
-                        <div class="title">{{ i.title }}</div>
+                        <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
                         <div v-if="i.show" class="carret">&#9660;</div>
                         <div v-else class="carret">&#9650;</div>
                     </div>
@@ -14,7 +14,7 @@
                         </g>
                         <g v-for="(block, $index) in i.groupings" :key="$index">
                             <title>{{ block }}</title>
-                            <text @click="select(block)" text-anchor="right" :x="5" :y="(blockHeight * $index) + 5 +(blockHeight / 2)">{{ block | truncate(52) }}</text>
+                            <text @click="select(block)" text-anchor="right" :x="15" :y="(blockHeight * $index) + 5 +(blockHeight / 2)">{{ block | truncate(52) }}</text>
                         </g>
                     </svg>
                 </div>
@@ -679,6 +679,7 @@
         cursor: pointer;
 
         .title {
+            padding: 0 0 0 10px;
             width: 90%;
         }
 

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -21,20 +21,30 @@
             </div>
 
             <div id="timeline-container" ref="container" @mousemove="move" @mouseup="mouseUp">
-                <div id="timeline" class="timeline" ref="timeline">
-
-                    <div v-for="(i, index) in groupByData" :key="index">
-                        <div id="timeline-dates" v-if="index === 0"></div>
-                        <svg ref="svg" id="timeline-events" :width="svgWidth" :height="i.show ? i.height + 35 : 0">
-                            <g class="titles" v-if="index === 0">
+                <div id="timeline" class="timeline" ref="timeline" :style="{'min-height': `${groupByData.length * blockHeight}px`}">
+                    <div id="timeline-dates" :style="{width: `${svgWidth}px`}">
+                     <svg ref="svg" :width="svgWidth" :height='22'>
+                            <g>
+                                <g>
+                                    <g class="titles">
                                 <g v-for="(line, $index) in gridLines" v-if="$index % smartGrids === 1" :key="$index">
                                     <text text-anchor="middle" :x="($index - 1) * hourWidth + titleWidth" y="20">{{ line }}</text>
                                 </g>
+
                                 <foreignObject :x='svgWidth - 500' width="1" height="100%" v-if="inifinteScroll">
                                     <v-waypoint @waypoint="collide" :horizontal="true"></v-waypoint>
                                 </foreignObject>
                             </g>
-                            <g v-if="i.show">
+                                </g>
+                            </g>
+                    </svg>
+                </div>
+                    <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + blockHeight : blockHeight}px`}">
+                        <svg ref="svg" id="timeline-events" :width="svgWidth" :height="i.show ? i.height + blockHeight : 0"  v-if="i.show">
+                            <g>
+                                <g>
+                                    <rect @click="i.show = false" x="0" :y="0" width="100%" fill="transparent" :height="blockHeight"></rect>
+                                </g>
                                 <g class="rows">
                                     <rect v-for="(block, $index) in i.groupings" x="0" :y="blockHeight * $index + 35" width="100%" :height="blockHeight" stroke="#f5f5f5" stroke-width="2" :key="$index"></rect>
                                 </g>

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -2,8 +2,8 @@
     <div>
         <div id="adpcalendar">
             <div id="timeline-sidebar">
-                <div v-if="categoryGroupings" v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + getTopMargin : getTopMargin}px`}">
-                    <div class="category-header-wrapper" :style="{'height': `${blockHeight}px`}">
+                <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + getTopMargin : getTopMargin}px`}">
+                    <div v-if="categoryGroupings" class="category-header-wrapper" :style="{'height': `${blockHeight}px`}">
                         <slot name="category-header" :data="i">
                             <div class="category-header" @click="i.show = !i.show">
                                 <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
@@ -22,15 +22,6 @@
                         </g>
                     </svg>
                 </div>
-                <svg v-else id="event-types" ref="svg" :width="titleWidth" :height='limits.height'>
-                    <g class="rows">
-                        <rect v-for="(block, $index) in groupings" x="0" :y="blockHeight * $index" width="100%" :height="blockHeight" stroke="#f5f5f5" stroke-width="2" :key="$index"></rect>
-                    </g>
-                    <g v-for="(block, $index) in groupings" :key="$index">
-                        <title>{{ block }}</title>
-                        <text @click="select(block)" text-anchor="right" :x="5" :y="(blockHeight * $index) + 5 +(blockHeight / 2)">{{ block | truncate(52) }}</text>
-                    </g>
-                </svg>
             </div>
 
             <div id="timeline-container" ref="container" @mousemove="move" @mouseup="mouseUp">

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -395,7 +395,7 @@
                 const position = this.calculate ? this.calculatedPosition : this.position
                 const titleGroupings = { misc: [] }
 
-                const startObj = this.categoryGroupings && this.categoryGroupings !== true ? this.categoryGroupings : { misc: [] }
+                const startObj = this.categoryGroupings !== true ? this.categoryGroupings : { misc: [] }
                 const test = this.nodes.reduce((grouped, item, i, array, sortKey = item.group_by) => {
                     if (this.categoryGroupings === true && sortKey) {
                         grouped[sortKey] = grouped[sortKey] || []

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -87,7 +87,7 @@
                                 </g>
                             </g>
                         </svg>
-                        <!-- <div v-else :style="{height: `${topMargin}px`}" @click="i.show =! i.show"></div> -->
+                        <div v-else id="closed-bar" :style="{width: `${svgWidth}px`, height: `${topMargin - 1}px`}" @click="i.show = !i.show"></div>
                     </div>
                 </div>
             </div>

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -433,7 +433,7 @@
                     title: group,
                     blocks: processNodes[group],
                     groupings: titleGroupings[group],
-                    show: clonedGroupByData.length && clonedGroupByData.map(g => g.title).indexOf(group) ? clonedGroupByData[clonedGroupByData.map(g => g.title).indexOf(group)].show : true,
+                    show: clonedGroupByData.length && clonedGroupByData.map(g => g.title).indexOf(group) > -1 ? clonedGroupByData[clonedGroupByData.map(g => g.title).indexOf(group)].show : true,
                     height: titleGroupings[group].length * (this.blockHeight),
                 }))
             },

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -580,8 +580,14 @@
 </script>
 
 <style lang="scss" scoped>
+    $header-border-size: 1px;
+    $header-border-colour: #eceaef;
+    $header-caret-colour: #666666;
+    $row-border: solid $header-border-size $header-border-colour;
+    $white: #ffffff;
+
     .rows rect {
-        fill: #fff;
+        fill: $white
     }
     .rows rect:nth-child(even) {
         fill: #f5f5f5;
@@ -673,25 +679,23 @@
     .category-header {
         display: flex;
         align-items: center;
-        justify-content: center;
-        font-weight: bold;
+
+        border: $row-border;
+        padding: 0 10px;
+
+        font-weight: 800;
         text-transform: capitalize;
-        border: solid 1px #eceaef;
+
         cursor: pointer;
 
         .title {
-            padding: 0 0 0 10px;
-            width: 90%;
-            text-align: left;
+            flex-grow: 1;
         }
 
         .caret {
+            flex-grow: 0;
             font-size: 2rem;
-            color: #666666;
-            width: 10%;
-            display: flex;
-            justify-content: center;
-            padding: 0 2px 3px 0;
+            color: $header-caret-colour;
             transform: scale(1, 1.3);
 
             &.collapsed {
@@ -701,9 +705,9 @@
         }
     }
 
-    .closed-bar {
+     .closed-bar {
         background-color: #f5f5f5;
-        border: solid 1px #eceaef;
+        border:  $row-border;
     }
 
     .grid-pattern {
@@ -712,7 +716,7 @@
 
     text.icon {
         font-family: Icons;
-        color: white;
+        color: $white;
         text-shadow: 0 0 1px rgba(0,0,0,0.5);
     }
 

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -455,9 +455,9 @@
                     })
                 } else {
                     this.$refs.ctxMenu[$index].open({
-                    pageX: e.offsetX,
-                    pageY: e.offsetY,
-                })
+                        pageX: e.offsetX,
+                        pageY: e.offsetY,
+                    })
                 }
             },
 

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -412,7 +412,7 @@
                 const titleGroupings = { misc: [] }
                 const startObj = this.categoryGroupings && this.categoryGroupings !== true ? this.categoryGroupings : { misc: [] }
 
-                const processNodes = this.nodes.reduce((grouped, item, i, array, sortKey = item.group_by) => {
+                const processNodes = this.repeats.reduce((grouped, item, i, array, sortKey = item.group_by) => {
                     if (this.categoryGroupings === true && sortKey) {
                         grouped[sortKey] = grouped[sortKey] || []
                     }
@@ -430,6 +430,25 @@
                         titleGroupings[computedSortKey].push(item.title.toLowerCase())
                     }
                     item.event_index = this.grouping ? index : i
+
+                    if (this.showRepeats && item.children && item.children.length) {
+                        item.children.map((ch) => {
+                            ch.event_index = index
+                            position(ch)
+                            return ch
+                        })
+                    }
+
+                    if (item.dependencies) {
+                        item.dependencies.map((dep) => {
+                            this.links.push([
+                                this.events[dep],
+                                item,
+                            ])
+
+                            return dep
+                        })
+                    }
 
                     position(item)
 

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -97,7 +97,7 @@
 
 <script>
     import moment from 'moment'
-    import _ from 'lodash'
+    import { cloneDeep } from 'lodash'
     import contextMenu from 'vue-context-menu'
 
     export default {
@@ -427,7 +427,7 @@
                     return grouped
                 }, startObj)
 
-                const clonedGroupByData = _.cloneDeep(this.groupByData)
+                const clonedGroupByData = cloneDeep(this.groupByData)
 
                 this.groupByData = Object.keys(processNodes).map(group => ({
                     title: group,
@@ -480,7 +480,7 @@
                 this.startMouse = evt
                 this.dragging = 'start'
                 this.localSelected = block
-                this.cloned = _.cloneDeep(this.localSelected)
+                this.cloned = cloneDeep(this.localSelected)
             },
 
             adjustEnd(block, evt) {
@@ -488,7 +488,7 @@
                 this.startMouse = evt
                 this.dragging = 'end'
                 this.localSelected = block
-                this.cloned = _.cloneDeep(this.localSelected)
+                this.cloned = cloneDeep(this.localSelected)
             },
 
             // move: _.debounce(function (evt) {

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -27,14 +27,14 @@
                             <g>
                                 <g>
                                     <g class="titles">
-                                <g v-for="(line, $index) in gridLines" v-if="$index % smartGrids === 1" :key="$index">
+                                        <g v-for="(line, $index) in gridLines" v-if="$index % smartGrids === 1" :key="$index">
                                             <text text-anchor="middle" :x="($index - 1) * hourWidth + titleWidth" y="10">{{ line }}</text>
-                                </g>
+                                        </g>
 
-                                <foreignObject :x='svgWidth - 500' width="1" height="100%" v-if="inifinteScroll">
-                                    <v-waypoint @waypoint="collide" :horizontal="true"></v-waypoint>
-                                </foreignObject>
-                            </g>
+                                        <foreignObject :x='svgWidth - 500' width="1" height="100%" v-if="inifinteScroll">
+                                            <v-waypoint @waypoint="collide" :horizontal="true"></v-waypoint>
+                                        </foreignObject>
+                                    </g>
                                 </g>
                             </g>
                     </svg>
@@ -616,26 +616,32 @@
     }
 
     #timeline-sidebar {
-        padding-top:0px;
+        padding-top: 35px;
         overflow: hidden;
         border-right: 5px solid rgba(200, 200, 200, 1);
         min-width: 300px;
     }
+
     #timeline-container {
         overflow-x: auto;
         margin-top: 0;
     }
 
     #timeline-dates {
-        // position: relative;
-        // top: 21px;
-        // height: 21px;
         display: flex;
+        margin-top: 12px;
+
+        svg {
+            border-bottom: solid;
+            border-width: 1px;
+            border-bottom-color: #eceaef;
+        }
     }
 
     #timeline {
         width: 100%;
         display: block;
+        padding-bottom: 10px;
         overflow-x: scroll;
     }
     #event-types {
@@ -661,14 +667,29 @@
     }
 
     #category-header {
-        border: solid;
-        border-color: whitesmoke;
-        border-width: 1px;
-        border-bottom: 0;
         height: 34px;
         display: flex;
         align-items: center;
         justify-content: center;
+        font-weight: bold;
+        text-transform: capitalize;
+        border-bottom: solid 1px #eceaef;
+        cursor: pointer;
+
+        .title {
+            width: 90%;
+        }
+
+        .carret {
+            font-size: 0.9rem;
+            width: 10%;
+            transform: scale(1.4,-0.8);
+        }
+    }
+
+    #closed-bar{
+        background-color: #f5f5f5;
+        border-bottom: solid 1px #eceaef;
     }
 
     .grid-pattern {

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -59,7 +59,7 @@
                                     </foreignObject>
 
                                     <g class="paths">
-                                        <path v-for="(link, index) in linkPaths" :d="link.path" :class="{critical: link.critical}" :key="index"/>
+                                        <path v-for="(link, index) in linkPaths[rootIndex]" :d="link.path" :class="{critical: link.critical}" :key="index"/>
                                     </g>
 
                                     <g class="blocks">
@@ -214,24 +214,27 @@
             },
 
             linkPaths() {
-                // if (!this.calculate) return []
-
-                return this.links.map((link) => {
-                    const startX = link[0].x + (link[0].width / 2)
-                    const startY = (link[0].y) + link[0].height
-                    const laneTop = link[1].y
-                    const endX = link[1].x
-                    const endY = (link[1].y) + (this.blockHeight / 3)
-                    link.path = `M${startX} ${startY}
-                                L ${startX} ${laneTop}
-                                a 12 12 0 0 0 12 12
-                                L ${endX} ${endY}
-                                M ${endX - 10} ${endY - 7}
-                                L ${endX} ${endY}
-                                L ${endX - 10} ${endY + 7}`
-                    link.critical = link[2] ? link[2] : false
-                    return link
+                const links = []
+                this.groupByData.forEach((group) => {
+                    links.push(group.links.map((link) => {
+                        const startX = link[0].x + (link[0].width / 2)
+                        const startY = (link[0].y) + link[0].height
+                        const laneTop = link[1].y
+                        const endX = link[1].x
+                        const endY = (link[1].y) + (this.blockHeight / 3)
+                        link.path = `M${startX} ${startY}
+                                    L ${startX} ${laneTop}
+                                    a 12 12 0 0 0 12 12
+                                    L ${endX} ${endY}
+                                    M ${endX - 10} ${endY - 7}
+                                    L ${endX} ${endY}
+                                    L ${endX - 10} ${endY + 7}`
+                        link.critical = link[2] ? link[2] : false
+                        return link
+                    }))
                 })
+
+                return links
             },
 
             smartGrids() {
@@ -377,6 +380,7 @@
             buildGroupByData() {
                 const position = this.calculate ? this.calculatedPosition : this.position
                 const titleGroupings = { misc: [] }
+                const links = { misc: [] }
                 const startObj = this.categoryGroupings && this.categoryGroupings !== true ? this.categoryGroupings : { misc: [] }
 
                 const processNodes = this.repeats.reduce((grouped, item, i, array, sortKey = item.group_by) => {
@@ -407,8 +411,9 @@
                     }
 
                     if (item.dependencies) {
+                        links[computedSortKey] = links[computedSortKey] || []
                         item.dependencies.map((dep) => {
-                            this.links.push([
+                            links[computedSortKey].push([
                                 this.events[dep],
                                 item,
                             ])
@@ -435,6 +440,7 @@
 
                 this.groupByData = Object.keys(filteredGroups).map(group => ({
                     title: group,
+                    links: links[group],
                     blocks: filteredGroups[group],
                     groupings: titleGroupings[group],
                     show: clonedGroupByData.length && clonedGroupByData.map(g => g.title).indexOf(group) > -1 ? clonedGroupByData[clonedGroupByData.map(g => g.title).indexOf(group)].show : true,

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -699,7 +699,6 @@
             transform: scale(1, 1.3);
 
             &.collapsed {
-                padding: 0;
                 transform: scale(1.3, 1) rotate(90deg);
             }
         }

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -530,6 +530,10 @@
 
                     this.cloned.ends_at = moment(this.cloned.ends_at).add(diff, 'days').format('YYYY-MM-DD')
                     position(this.cloned)
+                    this.localSelected.offset = this.cloned.offset
+                    this.localSelected.starts_at = this.cloned.starts_at
+                    this.localSelected.duration = this.cloned.duration
+
                     this.localSelected.x = this.cloned.x
                     this.localSelected.width = this.cloned.width
 
@@ -588,17 +592,7 @@
 
         watch: {
             groupings: 'buildGroupByData',
-
-            'currentEvent.offset': {
-                handler() {
-                    const position = this.calculate ? this.calculatedPosition : this.position
-                    position(this.currentEvent)
-                    if (!this.currentEvent.children) return
-                    this.currentEvent.children.forEach((child) => {
-                        position(child)
-                    })
-                },
-            },
+            repeats: 'buildGroupByData',
         },
     }
 </script>

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -59,7 +59,7 @@
                                     </foreignObject>
 
                                     <g class="paths">
-                                        <path v-for="link in linkPaths" :d="link.path" :class="{critical: link.critical}" :key="link"/>
+                                        <path v-for="(link, index) in linkPaths" :d="link.path" :class="{critical: link.critical}" :key="index"/>
                                     </g>
 
                                     <g class="blocks">
@@ -74,7 +74,7 @@
 
                                             <rect v-if="!readOnly && !block.readOnly" class="drag-handle" @mousedown.prevent="adjustEnd(block, $event)" rx="5" ry="5" :x="block.x + block.width - 10" :y='block.y' width='10' :height='block.height' fill="#ccc"/>
 
-                                            <rect v-if="showRepeats" v-for="child in block.children" rx="2" ry="2" :x="child.x" :y='child.y' :width='child.width' :height='child.height' class="repeat" :style="{fill: child.label}" :key="child">
+                                            <rect v-if="showRepeats" v-for="(child, index) in block.children" rx="2" ry="2" :x="child.x" :y='child.y' :width='child.width' :height='child.height' class="repeat" :style="{fill: child.label}" :key="index">
                                                 <title>{{ child.title }}</title>
                                             </rect>
                                         </g>

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -437,8 +437,8 @@
             buildGroupByData() {
                 const position = this.calculate ? this.calculatedPosition : this.position
                 const titleGroupings = { misc: [] }
-
                 const startObj = this.categoryGroupings && this.categoryGroupings !== true ? this.categoryGroupings : { misc: [] }
+
                 const processNodes = this.nodes.reduce((grouped, item, i, array, sortKey = item.group_by) => {
                     if (this.categoryGroupings === true && sortKey) {
                         grouped[sortKey] = grouped[sortKey] || []
@@ -460,22 +460,23 @@
 
                     position(item)
 
-                    const filteredGroups = {}
-                    Object.keys(grouped).forEach((prop) => {
-                        if (prop !== 'misc' && grouped[prop].length) { filteredGroups[prop] = grouped[prop] }
-                    })
-
-                    if (!grouped.misc || (grouped.misc && !grouped.misc.length)) return filteredGroups
-
-                    filteredGroups.misc = grouped.misc
-                    return filteredGroups
+                    return grouped
                 }, startObj)
+
+                const filteredGroups = {}
+                Object.keys(processNodes).forEach((prop) => {
+                    if (prop !== 'misc' && processNodes[prop].length) { filteredGroups[prop] = processNodes[prop] }
+                })
+
+                if (processNodes.misc && processNodes.misc.length) {
+                    filteredGroups.misc = processNodes.misc
+                }
 
                 const clonedGroupByData = cloneDeep(this.groupByData)
 
-                this.groupByData = Object.keys(processNodes).map(group => ({
+                this.groupByData = Object.keys(filteredGroups).map(group => ({
                     title: group,
-                    blocks: processNodes[group],
+                    blocks: filteredGroups[group],
                     groupings: titleGroupings[group],
                     show: clonedGroupByData.length && clonedGroupByData.map(g => g.title).indexOf(group) > -1 ? clonedGroupByData[clonedGroupByData.map(g => g.title).indexOf(group)].show : true,
                     height: titleGroupings[group].length * (this.blockHeight),

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -679,6 +679,9 @@
     }
 
     .category-header-wrapper {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
         border: $row-border;
     }
 

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -359,7 +359,7 @@
                     // curr.label = preset_labels[curr.preset_id]
                     curr.label = this.statusColors[curr.status]
 
-                    if (!this.showRepeats) {
+                    if (!this.showRepeats || !curr.frequency) {
                         masterEvents.push(curr)
                         return curr
                     }

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -465,7 +465,7 @@
                         if (prop !== 'misc' && grouped[prop].length) { filteredGroups[prop] = grouped[prop] }
                     })
 
-                    if (!grouped.misc) return filteredGroups
+                    if (!grouped.misc || (grouped.misc && !grouped.misc.length)) return filteredGroups
 
                     filteredGroups.misc = grouped.misc
                     return filteredGroups

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -55,7 +55,7 @@
 
                                 <g class="graph">
                                     <foreignObject width="100%" height="100%">
-                                        <div class="grid-pattern" :style="gridPatternStyles"></div>
+                                        <div class="grid-pattern" :style="[ gridPatternStyles, { height: `${i.height}px` } ]"></div>
                                     </foreignObject>
 
                                     <g class="paths">
@@ -299,7 +299,6 @@
                     end: this.endPeriod,
                     range: 0,
                     units: this.scale,
-                    height: this.groupings.length * (this.blockHeight),
                 }
 
                 this.events.map((event) => {
@@ -393,7 +392,6 @@
                 return {
                     marginTop: `${this.getTopMargin}px`,
                     marginLeft: `${this.titleWidth}px`,
-                    height: `${this.limits.height}px`,
                     backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='${this.scaleWidth * 7}' height='100' viewBox='0 0 ${this.scaleWidth * 7} 100'%3E%3Cg fill-rule='evenodd'%3E%3Cg fill='%239C92AC' fill-opacity='0.4'%3E%3Cpath opacity='.5' d='M0 0 H 5 V 100 H 0 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z m${this.scaleWidth} 0 h 1 V 100 h -1 Z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
                 }
             },

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -440,7 +440,7 @@
 
                 this.groupByData = Object.keys(filteredGroups).map(group => ({
                     title: group,
-                    links: links[group],
+                    links: links[group] || [],
                     blocks: filteredGroups[group],
                     groupings: titleGroupings[group],
                     show: clonedGroupByData.length && clonedGroupByData.map(g => g.title).indexOf(group) > -1 ? clonedGroupByData[clonedGroupByData.map(g => g.title).indexOf(group)].show : true,

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -451,12 +451,12 @@
                     })
                     this.$refs.ctxMenu[$index].open({
                         pageX: e.offsetX,
-                        pageY: e.offsetY,
+                        pageY: e.offsetY - 25,
                     })
                 } else {
                     this.$refs.ctxMenu[$index].open({
                         pageX: e.offsetX,
-                        pageY: e.offsetY,
+                        pageY: e.offsetY - 25,
                     })
                 }
             },

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -45,7 +45,7 @@
                         <svg ref="svg" id="timeline-events" :width="svgWidth" :height="i.show ? i.height + blockHeight : 0"  v-if="i.show">
                             <g>
                                 <g>
-                                    <rect @click="i.show = false" x="0" :y="0" width="100%" fill="transparent" :height="blockHeight"></rect>
+                                    <rect @click="i.show = false" x="0" :y="0" width="100%" fill="transparent" :height="blockHeight" stroke="#eceaef" stroke-width="2"></rect>
                                 </g>
                                 <g class="rows">
                                     <rect v-for="(block, $index) in i.groupings" x="0" :y="blockHeight * $index + blockHeight" width="100%" :height="blockHeight" stroke="#f5f5f5" stroke-width="2" :key="$index"></rect>
@@ -89,7 +89,7 @@
                                 </g>
                             </g>
                         </svg>
-                        <div v-else id="closed-bar" :style="{width: `${svgWidth}px`, height: `${topMargin - 1}px`}" @click="i.show = !i.show"></div>
+                        <div v-else id="closed-bar" :style="{width: `${svgWidth}px`, height: `${topMargin}px`}" @click="i.show = !i.show"></div>
                     </div>
                 </div>
             </div>
@@ -635,13 +635,7 @@
 
     #timeline-dates {
         display: flex;
-        margin-top: 12px;
-
-        svg {
-            border-bottom: solid;
-            border-width: 1px;
-            border-bottom-color: #eceaef;
-        }
+        margin-top: 13px;
     }
 
     #timeline {
@@ -673,13 +667,13 @@
     }
 
     #category-header {
-        height: 34px;
+        height: 35px;
         display: flex;
         align-items: center;
         justify-content: center;
         font-weight: bold;
         text-transform: capitalize;
-        border-bottom: solid 1px #eceaef;
+        border: solid 1px #eceaef;
         cursor: pointer;
 
         .title {
@@ -703,7 +697,7 @@
 
     #closed-bar{
         background-color: #f5f5f5;
-        border-bottom: solid 1px #eceaef;
+        border: solid 1px #eceaef;
     }
 
     .grid-pattern {

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -404,7 +404,7 @@
                 const position = this.calculate ? this.calculatedPosition : this.position
                 const titleGroupings = { misc: [] }
 
-                const startObj = this.categoryGroupings !== true ? this.categoryGroupings : { misc: [] }
+                const startObj = this.categoryGroupings && this.categoryGroupings !== true ? this.categoryGroupings : { misc: [] }
                 const processNodes = this.nodes.reduce((grouped, item, i, array, sortKey = item.group_by) => {
                     if (this.categoryGroupings === true && sortKey) {
                         grouped[sortKey] = grouped[sortKey] || []

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -384,6 +384,10 @@
                 return masterEvents
             },
 
+            getTopMargin() {
+                return this.categoryGroupings ? this.topMargin : 0
+            },
+
             gridPatternStyles() {
                 return {
                     marginTop: `${this.topMargin}px`,

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -427,11 +427,13 @@
                     return grouped
                 }, startObj)
 
+                const clonedGroupByData = _.cloneDeep(this.groupByData)
+
                 this.groupByData = Object.keys(processNodes).map(group => ({
                     title: group,
                     blocks: processNodes[group],
                     groupings: titleGroupings[group],
-                    show: true,
+                    show: clonedGroupByData.length && clonedGroupByData.map(g => g.title).indexOf(group) ? clonedGroupByData[clonedGroupByData.map(g => g.title).indexOf(group)].show : true,
                     height: titleGroupings[group].length * (this.blockHeight),
                 }))
             },

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -381,7 +381,7 @@
                 const position = this.calculate ? this.calculatedPosition : this.position
                 const titleGroupings = { misc: [] }
                 const links = { misc: [] }
-                const startObj = this.categoryGroupings && this.categoryGroupings !== true ? this.categoryGroupings : { misc: [] }
+                const startObj = cloneDeep(this.categoryGroupings && this.categoryGroupings !== true ? this.categoryGroupings : { misc: [] })
 
                 const processNodes = this.repeats.reduce((grouped, item, i, array, sortKey = item.group_by) => {
                     if (this.categoryGroupings === true && sortKey) {

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -43,7 +43,7 @@
                             </g>
                     </svg>
                 </div>
-                    <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + getTopMargin : getTopMargin}px`}">
+                    <div v-for="(i, rootIndex) in groupByData" :key="rootIndex" :style="{height: `${i.show ? i.height + getTopMargin : getTopMargin}px`}">
                         <svg ref="svg" id="timeline-events" :width="svgWidth" :height="i.show ? i.height + getTopMargin : 0"  v-if="i.show">
                             <g>
                                 <g>
@@ -66,7 +66,7 @@
                                         <g class="block" v-for="(block, $index) in i.blocks" :key="$index">
                                             <title>{{ block.title }}</title>
 
-                                            <rect @contextmenu.prevent="openContext($event, block)" @click="select(block, $index)" @mousedown="adjustStart(block, $event)" rx="2" ry="2" :x="block.x" :y='block.y' :width='block.width' :height='block.height' :class="{editable: !readOnly && !block.readOnly}" :style="{fill: block.label}">
+                                            <rect @contextmenu.prevent="openContext($event, block, rootIndex)" @click="select(block, $index)" @mousedown="adjustStart(block, $event)" rx="2" ry="2" :x="block.x" :y='block.y' :width='block.width' :height='block.height' :class="{editable: !readOnly && !block.readOnly}" :style="{fill: block.label}">
                                                 <title v-if="block.readOnly" >🔒{{ block.readOnly }}</title>
                                                 <title v-else>{{ block.title }}</title>
                                             </rect>
@@ -442,12 +442,23 @@
                 }))
             },
 
-            openContext(e, block) {
+            openContext(e, block, $index) {
                 this.localSelected = block
-                this.$refs.ctxMenu[0].open({
+
+                if (this.$refs.ctxMenu.length > 1) {
+                    this.$refs.ctxMenu.forEach((menu) => {
+                        menu.ctxVisible = false
+                    })
+                    this.$refs.ctxMenu[$index].open({
+                        pageX: e.offsetX,
+                        pageY: e.offsetY,
+                    })
+                } else {
+                    this.$refs.ctxMenu[$index].open({
                     pageX: e.offsetX,
                     pageY: e.offsetY,
                 })
+                }
             },
 
             collide(e) {

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -63,23 +63,7 @@
                                     </g>
 
                                     <g class="blocks">
-                                        <g v-if="categoryGroupings" class="block" v-for="(block, $index) in i.blocks" :key="$index">
-                                            <title>{{ block.title }}</title>
-
-                                            <rect @contextmenu.prevent="openContext($event, block)" @click="select(block, $index)" @mousedown="adjustStart(block, $event)" rx="2" ry="2" :x="block.x" :y='block.y' :width='block.width' :height='block.height' :class="{editable: !readOnly && !block.readOnly}" :style="{fill: block.label}">
-                                                <title v-if="block.readOnly" >🔒{{ block.readOnly }}</title>
-                                                <title v-else>{{ block.title }}</title>
-                                            </rect>
-                                            <text v-if="block.readOnly" :x="block.x + (block.width / 2)" :y="block.y + 2 * (block.height / 3)" style="font-family: Icons" class="icon" text-anchor="middle">&#xf023;</text>
-
-                                            <rect v-if="!readOnly && !block.readOnly" class="drag-handle" @mousedown.prevent="adjustEnd(block, $event)" rx="5" ry="5" :x="block.x + block.width - 10" :y='block.y' width='10' :height='block.height' fill="#ccc"/>
-
-                                            <rect v-if="showRepeats" v-for="child in block.children" rx="2" ry="2" :x="child.x" :y='child.y' :width='child.width' :height='child.height' class="repeat" :style="{fill: child.label}" :key="child">
-                                                <title>{{ child.title }}</title>
-                                            </rect>
-                                        </g>
-
-                                        <g v-else class="block" v-for="(block, $index) in nodes" :key="$index">
+                                        <g class="block" v-for="(block, $index) in i.blocks" :key="$index">
                                             <title>{{ block.title }}</title>
 
                                             <rect @contextmenu.prevent="openContext($event, block)" @click="select(block, $index)" @mousedown="adjustStart(block, $event)" rx="2" ry="2" :x="block.x" :y='block.y' :width='block.width' :height='block.height' :class="{editable: !readOnly && !block.readOnly}" :style="{fill: block.label}">

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -3,10 +3,10 @@
         <div id="adpcalendar">
             <div id="timeline-sidebar">
                 <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + blockHeight : blockHeight}px`}">
-                    <div id="category-header" @click="i.show =! i.show">
+                    <div id="category-header" slot="category-header" @click="i.show =! i.show">
                         <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
-                        <div v-if="i.show" class="carret">&rsaquo;</div>
-                        <div v-else class="carret collapsed">&rsaquo;</div>
+                        <div v-if="i.show" class="caret">&rsaquo;</div>
+                        <div v-else class="caret collapsed">&rsaquo;</div>
                     </div>
                     <svg id="event-types" ref="svg" :width="titleWidth" :height='i.height' v-if="i.show">
                         <g class="rows">
@@ -686,7 +686,7 @@
             text-align: left;
         }
 
-        .carret {
+        .caret {
             font-size: 2rem;
             color: #666666;
             width: 10%;

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -458,7 +458,7 @@
 
             openContext(e, block) {
                 this.localSelected = block
-                this.$refs.ctxMenu.open({
+                this.$refs.ctxMenu[0].open({
                     pageX: e.offsetX,
                     pageY: e.offsetY,
                 })

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -3,13 +3,15 @@
         <div id="adpcalendar">
             <div id="timeline-sidebar">
                 <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + blockHeight : blockHeight}px`}">
-                    <slot name="category-header" :data="i">
-                        <div class="category-header" :style="{'height': `${blockHeight}px`}" @click="i.show =! i.show">
-                            <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
-                            <div v-if="i.show" class="caret collapsed">&rsaquo;</div>
-                            <div v-else class="caret">&rsaquo;</div>
-                        </div>
-                    </slot>
+                    <div class="category-header-wrapper">
+                        <slot name="category-header" :data="i">
+                            <div class="category-header" :style="{'height': `${blockHeight}px`}" @click="i.show =! i.show">
+                                <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
+                                <div v-if="i.show" class="caret collapsed">&rsaquo;</div>
+                                <div v-else class="caret">&rsaquo;</div>
+                            </div>
+                        </slot>
+                    </div>
                     <svg id="event-types" ref="svg" :width="titleWidth" :height='i.height' v-if="i.show">
                         <g class="rows">
                             <rect v-for="(block, $index) in i.groupings" x="0" :y="blockHeight * $index" width="100%" :height="blockHeight" stroke="#f5f5f5" stroke-width="2" :key="$index"></rect>
@@ -676,11 +678,13 @@
         display: flex;
     }
 
+    .category-header-wrapper {
+        border: $row-border;
+    }
+
     .category-header {
         display: flex;
         align-items: center;
-
-        border: $row-border;
         padding: 0 10px;
 
         font-weight: 800;

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -568,7 +568,7 @@
         },
 
         watch: {
-            nodes: 'buildGroupByData',
+            groupings: 'buildGroupByData',
         },
     }
 </script>
@@ -695,7 +695,7 @@
 
             &.collapsed {
                 transform: translateX(-2.5px) translateY(-4px) scale(1.8, 1);
-        }
+            }
         }
     }
 

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -5,8 +5,8 @@
                 <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + blockHeight : blockHeight}px`}">
                     <div id="category-header" @click="i.show =! i.show">
                         <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
-                        <div v-if="i.show" class="carret">&#9660;</div>
-                        <div v-else class="carret">&#9650;</div>
+                        <div v-if="i.show" class="carret">&rsaquo;</div>
+                        <div v-else class="carret-collapsed">&rsaquo;</div>
                     </div>
                     <svg id="event-types" ref="svg" :width="titleWidth" :height='i.height' v-if="i.show">
                         <g class="rows">

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -2,8 +2,12 @@
     <div>
         <div id="adpcalendar">
             <div id="timeline-sidebar">
-                <div v-for="(i, index) in groupByData" :key="index">
-                    <div id="category-header" @click="i.show =! i.show">{{ i.title }}</div>
+                <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + blockHeight : blockHeight}px`}">
+                    <div id="category-header" @click="i.show =! i.show">
+                        <div class="title">{{ i.title }}</div>
+                        <div v-if="i.show" class="carret">&#9660;</div>
+                        <div v-else class="carret">&#9650;</div>
+                    </div>
                     <svg id="event-types" ref="svg" :width="titleWidth" :height='i.height' v-if="i.show">
                         <g class="rows">
                             <rect v-for="(block, $index) in i.groupings" x="0" :y="blockHeight * $index" width="100%" :height="blockHeight" stroke="#f5f5f5" stroke-width="2" :key="$index"></rect>

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -411,7 +411,9 @@
                     }
 
                     const computedSortKey = grouped[sortKey] ? sortKey : 'misc'
-                    grouped[computedSortKey].push(item)
+
+                    const group = grouped[computedSortKey]
+                    if (group.indexOf(item) === -1) group.push(item)
 
                     titleGroupings[computedSortKey] = titleGroupings[computedSortKey] || []
 

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -3,7 +3,7 @@
         <div id="adpcalendar">
             <div id="timeline-sidebar">
                 <div v-for="(i, index) in groupByData" :key="index" :style="{height: `${i.show ? i.height + blockHeight : blockHeight}px`}">
-                    <div id="category-header" slot="category-header" @click="i.show =! i.show">
+                    <div id="category-header" slot="category-header" :data="i" @click="i.show =! i.show">
                         <div class="title">{{ i.title }} ({{ i.blocks.length }})</div>
                         <div v-if="i.show" class="caret">&rsaquo;</div>
                         <div v-else class="caret collapsed">&rsaquo;</div>

--- a/src/components/Gantt.vue
+++ b/src/components/Gantt.vue
@@ -428,7 +428,11 @@
 
                     position(item)
 
-                    return grouped
+                    const filteredGroups = {}
+                    Object.keys(grouped).forEach((prop) => {
+                        if (grouped[prop].length) { filteredGroups[prop] = grouped[prop] }
+                    })
+                    return filteredGroups
                 }, startObj)
 
                 const clonedGroupByData = cloneDeep(this.groupByData)


### PR DESCRIPTION
This brings in changes to enable us to group events by category's by passing a group_by prop on events and passing in a new categoryGrouping array to specify an ordered list of category's or a boolean
- True: to generate the category list from the values in the group_by prop
- False: To place all events in a single misc category (default)

It also adds a scoped slot for passing in a custom category header, adds tree-shaking for our use of lodash and utilises an iso caret icon for the default category headers to show the collapse state

and any logic/styling changes to go with the above, it also adds the semantic ui css for use when testing the repo locally

A seperate PR for tests for the new groupByData logic will follow this in the near future.

